### PR TITLE
Fix Journal Build on Linux and Ci using meson instead of meson setup

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Build executable
         run: |
           source linux/vars.sh
-          meson build --bindir=. --prefix=$GITHUB_WORKSPACE/build/lib
+          meson setup build --bindir=. --prefix=$GITHUB_WORKSPACE/build/lib
           cd build
           ninja
           ninja install

--- a/journal/meson.build
+++ b/journal/meson.build
@@ -52,13 +52,25 @@ if host_system == 'windows'
     link_args += ['-lws2_32', '-liphlpapi']
 endif
 
-executable(
-    '_______',
-    sources: sources,
-    dependencies: [sdl3, boost],
-    link_args: link_args,
-    win_subsystem: 'windows',
-    include_directories: includes,
-)
+if host_system != 'windows'
+    iconv = compilers['cpp'].find_library('iconv')
+    executable(
+        '_______',
+        sources: sources,
+        dependencies: [sdl3, boost, iconv],
+        link_args: link_args,
+        win_subsystem: 'windows',
+        include_directories: includes,
+    )
+else
+    executable(
+        '_______',
+        sources: sources,
+        dependencies: [sdl3, boost],
+        link_args: link_args,
+        win_subsystem: 'windows',
+        include_directories: includes,
+    )
+endif
 
 global_include_dirs += include_directories('common')


### PR DESCRIPTION
The journal wouldn't build for me without iconv
Also made the Linux ci use meson setup like the windows one for consistency
```
FAILED: [code=1] journal/_______ 
c++  -o journal/_______ journal/_______.p/journal.cpp.o journal/_______.p/niko_handling.cpp.o journal/_______.p/journal_handling.cpp.o journal/_______.p/renderer.cpp.o journal/_______.p/.._src_oneshot_xdg-user-dir-lookup.c.o -L/home/paulo/Repos/osfm-mkxp-z/linux/build-x86_64/lib -Wl,--as-needed -Wl,--no-undefined -Wl,-O1 -static-libgcc -static-libstdc++ -Wl,-Bstatic -Wl,--start-group -lgcc -lstdc++ -lpthread -pthread /home/paulo/Repos/osfm-mkxp-z/linux/build-x86_64/lib/libSDL3.a -Wl,--end-group
/usr/bin/ld: /home/paulo/Repos/osfm-mkxp-z/linux/build-x86_64/lib/libSDL3.a(SDL_iconv.c.o): in function `SDL_iconv_REAL':
SDL_iconv.c:(.text+0x3b): undefined reference to `libiconv'
/usr/bin/ld: /home/paulo/Repos/osfm-mkxp-z/linux/build-x86_64/lib/libSDL3.a(SDL_iconv.c.o): in function `SDL_iconv_string_REAL':
SDL_iconv.c:(.text+0xf3): undefined reference to `libiconv_open'
/usr/bin/ld: SDL_iconv.c:(.text+0x1c7): undefined reference to `libiconv'
/usr/bin/ld: SDL_iconv.c:(.text+0x200): undefined reference to `libiconv_close'
/usr/bin/ld: SDL_iconv.c:(.text+0x2a8): undefined reference to `libiconv_close'
/usr/bin/ld: /home/paulo/Repos/osfm-mkxp-z/linux/build-x86_64/lib/libSDL3.a(SDL_iconv.c.o): in function `SDL_iconv_open_REAL':
SDL_iconv.c:(.text+0x1): undefined reference to `libiconv_open'
/usr/bin/ld: /home/paulo/Repos/osfm-mkxp-z/linux/build-x86_64/lib/libSDL3.a(SDL_iconv.c.o): in function `SDL_iconv_close_REAL':
SDL_iconv.c:(.text+0x17): undefined reference to `libiconv_close'
collect2: error: ld returned 1 exit status
``` 